### PR TITLE
fix(env): update API URL environment variable name

### DIFF
--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -74,7 +74,7 @@ export default function HistoryPage() {
       setError(null);
       
       // Build API URL with parameters
-      const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+      const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
       const params = new URLSearchParams();
       
       if (limitParam) {


### PR DESCRIPTION
The environment variable was renamed from NEXT_PUBLIC_API_URL to NEXT_PUBLIC_API_BASE_URL to match the updated configuration